### PR TITLE
ci: add windows-latest to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,14 @@ concurrency:
 
 jobs:
   check:
-    name: Check
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
+    name: Check (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -29,7 +34,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      # Formatting is platform-independent — checking it once is enough.
       - name: Rustfmt
+        if: runner.os == 'Linux'
         run: cargo fmt --check
 
       - name: Clippy
@@ -38,13 +45,16 @@ jobs:
       - name: Test
         run: cargo test --locked --workspace
 
+      # The frontend build is platform-independent and slow; Linux only.
       - uses: actions/setup-node@v4
+        if: runner.os == 'Linux'
         with:
           node-version-file: crates/markplane-web/ui/.nvmrc
           cache: npm
           cache-dependency-path: crates/markplane-web/ui/package-lock.json
 
       - name: Frontend lint & build
+        if: runner.os == 'Linux'
         working-directory: crates/markplane-web/ui
         run: |
           npm ci


### PR DESCRIPTION
## Summary

CI ran Rust clippy and tests only on `ubuntu-latest`. Windows-specific defects were structurally invisible.

This is the direct cause of #35 sitting undetected: `lock_item()` took an `fs2` byte-range lock on the item file itself, which on Windows blocks the `NamedTempFile::persist()` in `write_item()` from replacing it (`os error 33`, `ERROR_LOCK_VIOLATION`). Every mutating operation — `update_status`, `update_task/epic/plan/note`, `link_items` — failed on Windows. `release.yml` builds a Windows binary but only smoke-tests `--version`, so it caught nothing either.

Adding Windows here is a prerequisite for merging #35: without it, a regression test for that bug passes on Linux whether or not the bug exists, because `flock` never blocked renames.

## What runs where

| Step | Linux | Windows |
|------|-------|---------|
| Rustfmt | ✅ | — platform-independent |
| Clippy | ✅ | ✅ |
| Test | ✅ | ✅ |
| Frontend lint & build | ✅ | — platform-independent, slow |

`fail-fast: false` so one platform failing still reports the other. Timeout 20 → 30 minutes for cold-cache Windows builds.

## Expected

First Windows run may surface pre-existing unrelated failures. That is the point of the change, and the reason it lands separately from the #35 fix rather than bundled into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GR33TA8BuP9NAKh3PALrVc