### PR TITLE
chore: document cross-platform CI and align check commands

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,11 @@ Describe the changes and the motivation behind them.
 
 ## How Tested
 
-- [ ] `cargo test --workspace` passes
-- [ ] `cargo clippy --workspace` passes (no warnings)
+- [ ] `cargo test --locked --workspace` passes
+- [ ] `cargo clippy --locked --workspace --all-targets -- -D warnings` passes
 - [ ] Manual testing (describe what you tested):
+
+CI runs these on both Linux and Windows; both must pass to merge.
 
 ## Breaking Changes
 

--- a/.markplane/backlog/items/TASK-sk3g3.md
+++ b/.markplane/backlog/items/TASK-sk3g3.md
@@ -1,0 +1,83 @@
+---
+id: TASK-sk3g3
+title: Document cross-platform CI decision
+status: done
+priority: low
+type: chore
+effort: xs
+epic: null
+plan: null
+depends_on: []
+blocks: []
+related: []
+assignee: null
+tags:
+- ci
+position: a7
+created: 2026-09-02
+updated: 2026-09-02
+---
+
+# Document cross-platform CI decision
+
+## Description
+
+CI ran on `ubuntu-latest` only from its creation ([[TASK-yzftd]]) until
+2026-09-02, when `windows-latest` was added in #48. That original decision
+carried an explicit escape clause:
+
+> **Linux-only CI**: macOS runners are 10x more expensive and slower to
+> provision. Platform-specific compile/link issues are caught by the release
+> workflow which builds on macOS and Windows. Add macOS to CI only if
+> platform-specific test failures emerge.
+
+Platform-specific test failures emerged. #35 reported that every mutating
+operation failed on Windows with `os error 33`, and the first Windows CI run
+confirmed it: 27 of 75 CLI integration tests failed, and the core and MCP
+suites never ran at all. The clause fired exactly as written, so #48 honors
+the original decision rather than reversing it.
+
+That reasoning currently lives only in a PR body. This repo keeps CI
+decisions in task files, so it is recorded here.
+
+## Acceptance Criteria
+
+- [x] The rationale for adding `windows-latest` is recorded alongside the
+      original Linux-only decision
+- [x] CONTRIBUTING.md tells contributors which platforms CI runs on
+- [x] The PR template checklist matches the commands CI actually runs
+
+## Decisions
+
+- **Windows, not macOS**: the cost argument that justified Linux-only does
+  not extend equally. GitHub bills Windows runners at 2x and macOS at 10x, so
+  Windows is an order of magnitude cheaper to add. macOS stays out of CI and
+  remains covered by the release workflow's build matrix.
+- **Clippy and tests on both platforms, rustfmt and frontend on Linux only**:
+  formatting is textual and platform-independent, and the Next.js build does
+  not vary by runner OS. Duplicating either adds minutes for no signal.
+  Clippy runs on both because lints can be `cfg`-gated.
+- **`fail-fast: false`**: one platform failing must not cancel the other, or a
+  Windows failure would hide the Linux result and vice versa.
+- **Timeout raised 20 -> 30 minutes**: Windows Rust builds are materially
+  slower on a cold cache.
+- **Required status checks updated in the `master-protection` ruleset**: the
+  job rename from `Check` to `Check (${{ matrix.os }})` orphaned the required
+  context, blocking every PR to master until both new contexts were
+  registered. Renaming a CI job that a ruleset requires is a breaking change
+  to the merge gate — check `/rulesets`, not just
+  `/branches/master/protection`, which does not report rulesets.
+
+## Notes
+
+- The class of bug this catches was invisible for months: `release.yml` builds
+  a Windows binary but only smoke-tests `--version`, so it never exercised the
+  code paths that were broken. Expanding those smoke tests is [[TASK-t672g]].
+- Windows is now a required check, so this class of regression cannot merge
+  past CI again.
+
+## References
+
+- [[TASK-yzftd]]
+- [[TASK-t672g]]
+- [[EPIC-bb6pe]]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,34 @@ cargo clippy --workspace
 
 All code must be clippy-clean with no warnings.
 
+## Continuous Integration
+
+Every push and pull request runs CI on **both `ubuntu-latest` and
+`windows-latest`**. Both platform checks must pass before a PR can merge.
+
+| Step | Linux | Windows |
+|------|-------|---------|
+| `cargo fmt --check` | ✅ | — |
+| `cargo clippy --locked --workspace --all-targets -- -D warnings` | ✅ | ✅ |
+| `cargo test --locked --workspace` | ✅ | ✅ |
+| `npm ci && npm run lint && npm run build` | ✅ | — |
+
+Formatting and the frontend build are platform-independent, so they run once
+on Linux. Clippy and the test suite run on both, because that is where
+platform differences surface.
+
+Two failure modes this catches that testing on a single machine will not:
+
+- **Platform-specific behavior.** File locking, path separators, and line
+  endings differ on Windows. A change can pass locally on macOS or Linux and
+  still fail CI — this is not hypothetical, it is why the matrix exists.
+- **Stale lockfiles.** CI passes `--locked` to cargo and uses `npm ci`, so a
+  `Cargo.lock` or `package-lock.json` out of sync with its manifest fails the
+  build. Commit lockfile updates alongside dependency changes.
+
+macOS is not in the CI matrix; the release workflow builds and smoke-tests
+macOS binaries.
+
 ## Error Handling Conventions
 
 Each crate uses a different error strategy appropriate to its role:
@@ -136,7 +164,7 @@ git rebase upstream/master
 
 - Write clear commit messages summarizing the "why", not just the "what".
 - Keep commits focused — one logical change per commit.
-- Ensure `cargo test --workspace` and `cargo clippy --workspace` pass before committing.
+- Ensure `cargo test --locked --workspace` and `cargo clippy --locked --workspace --all-targets -- -D warnings` pass before committing — these are what CI runs.
 
 ### Conventional Commits
 


### PR DESCRIPTION
## What Changed

CI gained `windows-latest` in #48, but nothing in the docs said so. A contributor reading CONTRIBUTING.md had no way to know their PR runs on two platforms, or that Windows-only failures are a thing that happens here.

**CONTRIBUTING.md** — new Continuous Integration section: what runs on which platform and why (formatting and the frontend build are platform-independent, so they run once on Linux; clippy and tests run on both), plus the two failure modes single-machine testing misses.

**Check commands aligned with reality.** CONTRIBUTING.md and the PR template both asked for bare `cargo test --workspace` / `cargo clippy --workspace`. CI runs `--locked` and `--all-targets -- -D warnings`. That gap is not theoretical — #35 passed its author's local checks and would have failed CI on `clippy::suspicious_open_options`, which only fires under `--all-targets`.

**TASK-sk3g3** records the decision. Archived TASK-yzftd set the original Linux-only policy with an explicit clause: *"Add macOS to CI only if platform-specific test failures emerge."* That clause fired — 27 of 75 CLI integration tests failed on the first Windows run — so #48 honors the original decision rather than reversing it. The task also notes why Windows and not macOS (2x runner cost vs 10x), and the ruleset trap: renaming a CI job that a ruleset requires silently blocks every PR to master, and `/branches/master/protection` does not report rulesets.

## How Tested

- [x] `cargo test --locked --workspace` passes
- [x] `cargo clippy --locked --workspace --all-targets -- -D warnings` passes
- [x] Docs-only change; no code touched
- [x] This PR exercises the repaired `master-protection` ruleset — the required contexts were orphaned by #48's job rename and re-registered afterward

## Breaking Changes

- [ ] This PR includes breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GR33TA8BuP9NAKh3PALrVc