### PR TITLE
docs: document the Homebrew trust step for the tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,24 @@ See the [AI Integration Guide](docs/ai-integration.md) for the full context laye
 ### Homebrew (macOS and Linux)
 
 ```bash
+brew trust zerowand01/markplane
 brew install zerowand01/markplane/markplane
 ```
+
+Homebrew 6.0+ requires third-party taps to be trusted before their formulae
+will load. Formulae are executable Ruby, and only official taps are
+pre-reviewed, so Homebrew asks you to opt in explicitly. Without the first
+command you'll see `Error: Refusing to load formula ... from untrusted tap`.
+Trust is recorded in `~/.homebrew/trust.json` and is set once per machine.
+
+To upgrade later:
+
+```bash
+brew update && brew upgrade markplane
+```
+
+`brew update` refreshes the tap's metadata — without it Homebrew still
+believes your installed version is current and reports nothing to upgrade.
 
 ### Shell script (macOS and Linux)
 


### PR DESCRIPTION
## What Changed

Homebrew 6.0 gates third-party taps behind `brew trust`. Following the README's first install option now fails on any current Homebrew:

```
Error: Refusing to load formula zerowand01/markplane/markplane
from untrusted tap zerowand01/markplane.
```

Formulae are executable Ruby and only official taps are pre-reviewed, so Homebrew 6 made that consent explicit rather than implied by typing the tap name. The gate is correct; the README just doesn't mention it.

This matters because it's a new user's *first* interaction with markplane, and "untrusted tap" reads as a warning about the software rather than a routine third-party gate. Note the asymmetry it created: the shell-script path is unaffected — `install.sh` pulls release binaries and verifies checksums without touching brew — so the documented first option was the one that failed while the fallback quietly worked.

Also documents `brew update` before `brew upgrade`. Without it Homebrew still considers the installed version current and reports nothing to do, which is exactly what happened when upgrading to v0.1.3.

## How Tested

- [x] Reproduced against Homebrew 6.0.21 with the tap already installed
- [x] Docs-only change; no code touched

## Breaking Changes

- [ ] This PR includes breaking changes